### PR TITLE
Fixed setup of wsdl files

### DIFF
--- a/onvif/client.py
+++ b/onvif/client.py
@@ -12,8 +12,8 @@ from zeep.client import Client, CachingClient
 from zeep.wsse.username import UsernameToken
 import zeep.helpers
 
-from exceptions import ONVIFError
-from definition import SERVICES
+from onvif.exceptions import ONVIFError
+from onvif.definition import SERVICES
 #from suds.sax.date import UTC
 import datetime as dt
 # Ensure methods to raise an ONVIFError Exception

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,6 @@ CLASSIFIERS = [
 ]
 
 wsdl_files = [os.path.join('wsdl', item) for item in os.listdir('wsdl')]
-wsdl_dst_dir = 'Lib/site-packages/wsdl' if sys.platform == 'win32' else \
-               'lib/python%d.%d/site-packages/wsdl' % (sys.version_info.major,
-                                                       sys.version_info.minor)
 
 setup(
       name='onvif_zeep',
@@ -49,7 +46,7 @@ setup(
       packages=find_packages(exclude=['docs', 'examples', 'tests']),
       install_requires=requires,
       include_package_data=True,
-      data_files=[(wsdl_dst_dir, wsdl_files)],
+      data_files=[('wsdl', wsdl_files)],
       entry_points={
           'console_scripts': ['onvif-cli = onvif.cli:main']
           }


### PR DESCRIPTION
Hello.
This fix is related to issue #13 
After applying it wsdls will be installed in proper place:
lib/python<proper_version>/site-packages/onvif_zeep-<version>-py<version>.egg/onvif
