### PR TITLE
Make super() syntax compatible with Python 2

### DIFF
--- a/onvif/client.py
+++ b/onvif/client.py
@@ -36,7 +36,7 @@ class UsernameDigestTokenDtDiff(UsernameToken):
     this should only be used in "safe" environments.
     """
     def __init__(self, user, passw, dt_diff=None, **kwargs):
-        super().__init__(user, passw, **kwargs)
+        super(UsernameDigestTokenDtDiff, self).__init__(user, passw, **kwargs)
         self.dt_diff = dt_diff  # Date/time difference in datetime.timedelta
 
     def apply(self, envelope, headers):
@@ -45,7 +45,7 @@ class UsernameDigestTokenDtDiff(UsernameToken):
             self.created = dt.datetime.utcnow()
         if self.dt_diff is not None:
             self.created += self.dt_diff
-        result = super().apply(envelope, headers)
+        result = super(UsernameDigestTokenDtDiff, self).apply(envelope, headers)
         self.created = old_created
         return result
 


### PR DESCRIPTION
This is a minor change to the usage of super() within client.py to maintain Python 2 compatibility. I believe this should resolve issue #33. 