### PR TITLE
Use natted ip/port instead of local passed in onvif response

### DIFF
--- a/onvif/client.py
+++ b/onvif/client.py
@@ -231,6 +231,18 @@ class ONVIFCamera(object):
         self.xaddrs = {}
         capabilities = self.devicemgmt.GetCapabilities({'Category': 'All'})
         for name in capabilities:
+            try:
+                retrived_address=capabilities[name].XAddr
+                right=retrived_address.split("//")[1]
+                retrived_url=right.split("/")[0]
+                ip_address=retrived_url.split(":")[0]
+                port_address = retrived_url.split(":")[1]
+                if (self.host != ip_address or self.port != port_address):
+                    remaining=right.split("/")[1]
+                    new_address="http://"+self.host+":"+str(self.port)+"/"+right.split("/")[1]+"/"+right.split("/")[2]
+                    capabilities[name].XAddr=new_address
+            except:
+                pass
             capability = capabilities[name]
             try:
                 if name.lower() in SERVICES and capability is not None:


### PR DESCRIPTION
add the ability to rewrite the address and the port if the camera is in a router with nat. When a camera is behind nat, all the ip/port information received in onvif response, is of local network instead of natted. This patch will use the natted ip/port from where the response is received.