### PR TITLE
Do not call logging.basicConfig() in library code

### DIFF
--- a/onvif/cli.py
+++ b/onvif/cli.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 '''ONVIF Client Command Line Interface'''
 from __future__ import print_function, division
+import logging
 import re
 from cmd import Cmd
 from ast import literal_eval
@@ -13,6 +14,8 @@ from onvif.definition import SERVICES
 import os.path
 
 SUPPORTED_SERVICES = SERVICES.keys()
+
+logging.basicConfig(level=logging.INFO)
 
 class ThrowingArgumentParser(ArgumentParser):
     def error(self, message):

--- a/onvif/client.py
+++ b/onvif/client.py
@@ -13,7 +13,6 @@ from onvif.exceptions import ONVIFError
 from onvif.definition import SERVICES
 
 logger = logging.getLogger('onvif')
-logging.basicConfig(level=logging.INFO)
 logging.getLogger('zeep.client').setLevel(logging.CRITICAL)
 
 


### PR DESCRIPTION
`logging.basicConfig()` is meant for application code. In `client.py`, it was setting up logging even when used as a library.

We run into this in [frigate](https://github.com/blakeblackshear/frigate/pull/13785#pullrequestreview-2309546837).