### PR TITLE
fix: Invalid dash-separated key 'description-file' in 'metadata' (set…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.rst
+long_description = file: README.rst


### PR DESCRIPTION
…up.cfg)