### PR TITLE
wsdl installation path compatible with virtual environments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
+"""Setup script for the onvif_zeep package."""
 import os
+import sysconfig
+import shutil
 from setuptools import setup, find_packages
-import sys
+from setuptools.command.install import install
+
 
 here = os.path.abspath(os.path.dirname(__file__))
 version_path = os.path.join(here, 'onvif/version.txt')
@@ -28,29 +32,44 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.5",
 ]
 
-wsdl_files = [os.path.join('wsdl', item) for item in os.listdir('wsdl')]
-wsdl_dst_dir = 'Lib/site-packages/wsdl' if sys.platform == 'win32' else \
-               'lib/python%d.%d/site-packages/wsdl' % (sys.version_info.major,
-                                                       sys.version_info.minor)
+
+class CustomInstallCommand(install):
+    """Custom install command to handle WSDL files."""
+    def run(self):
+        # Run regular installation first
+        install.run(self)
+
+        # Now manually copy the wsdl files to site-packages/wsdl
+        wsdl_src_dir = 'wsdl'
+        wsdl_dst_dir = os.path.join(sysconfig.get_paths()['purelib'], 'wsdl')
+
+        os.makedirs(wsdl_dst_dir, exist_ok=True)
+
+        for file in os.listdir(wsdl_src_dir):
+            src_path = os.path.join(wsdl_src_dir, file)
+            dst_path = os.path.join(wsdl_dst_dir, file)
+            shutil.copyfile(src_path, dst_path)
+
 
 setup(
-      name='onvif_zeep',
-      version=version,
-      description='Python Client for ONVIF Camera',
-      long_description=open('README.rst', 'r').read(),
-      author='Cherish Chen',
-      author_email='sinchb128@gmail.com',
-      maintainer='sinchb',
-      maintainer_email='sinchb128@gmail.com',
-      license='MIT',
-      keywords=['ONVIF', 'Camera', 'IPC'],
-      url='http://github.com/quatanium/python-onvif',
-      zip_safe=False,
-      packages=find_packages(exclude=['docs', 'examples', 'tests']),
-      install_requires=requires,
-      include_package_data=True,
-      data_files=[(wsdl_dst_dir, wsdl_files)],
-      entry_points={
-          'console_scripts': ['onvif-cli = onvif.cli:main']
-          }
-     )
+    name='onvif_zeep',
+    version=version,
+    description='Python Client for ONVIF Camera',
+    long_description=open('README.rst', 'r').read(),
+    author='Cherish Chen',
+    author_email='sinchb128@gmail.com',
+    maintainer='sinchb',
+    maintainer_email='sinchb128@gmail.com',
+    license='MIT',
+    keywords=['ONVIF', 'Camera', 'IPC'],
+    url='http://github.com/quatanium/python-onvif',
+    zip_safe=False,
+    packages=find_packages(exclude=['docs', 'examples', 'tests']),
+    install_requires=requires,
+    entry_points={
+        'console_scripts': ['onvif-cli = onvif.cli:main']
+    },
+    cmdclass={
+        'install': CustomInstallCommand,
+    },
+)


### PR DESCRIPTION
Currently, the package is installed incorrectly for Virtual Environments where the Python interpreter version is different from the system-wise Python version.

- This fix uses sysconfig which gives the correct path regardless of the environment.
- Opting for using a CustomInstallCommand since the previous setup data_files parameter expects relative paths rather than absolute paths. 